### PR TITLE
Fixes for tail extrapolation in Vignette and Chainladder.R

### DIFF
--- a/R/ChainLadder.R
+++ b/R/ChainLadder.R
@@ -11,9 +11,9 @@ chainladder <- function(Triangle, weights=1,
 
 
     ## Mack uses alpha between 0 and 2 to distinguish
-    ## alpha = 0 ordinary regression with intercept 0
+    ## alpha = 0 straight averages
     ## alpha = 1 historical chain ladder age-to-age factors
-    ## alpha = 2 straight averages
+    ## alpha = 2 ordinary regression with intercept 0
 
     ## However, in Zehnwirth & Barnett they use the notation of delta, whereby delta = 2 - alpha
     ## the delta is than used in a linear modelling context.
@@ -88,7 +88,7 @@ tailfactor <- function (clratios){
     if (f[n - 2] * f[n - 1] > 1.0001) {
         fn <- which(clratios > 1)
         f <- clratios[fn]
-        n <- length(f)
+        n <- max(fn)
         tail.model <- lm(log(f - 1) ~ fn)
         co <- coef(tail.model)
         tail <- exp(co[1] + c((n+1):(n + 100)) * co[2]) + 1

--- a/R/MackChainLadderFunctions.R
+++ b/R/MackChainLadderFunctions.R
@@ -30,9 +30,9 @@ MackChainLadder <- function(
     ## Create chain ladder models
     
     ## Mack uses alpha between 0 and 2 to distinguish
-    ## alpha = 0 ordinary regression with intercept 0
+    ## alpha = 0 straight averages
     ## alpha = 1 historical chain ladder age-to-age factors
-    ## alpha = 2 straight averages
+    ## alpha = 2 ordinary regression with intercept 0
     
     ## However, in Zehnwirth & Barnett they use the notation of delta, whereby delta = 2 - alpha
     ## the delta is than used in a linear modelling context.

--- a/vignettes/ChainLadder.Rnw
+++ b/vignettes/ChainLadder.Rnw
@@ -507,7 +507,7 @@ tail.model <- lm(log(f-1) ~ dev.period)
 abline(tail.model)
 co <- coef(tail.model)
 ## extrapolate another 100 dev. period
-tail <- exp(co[1] + c((n + 1):(n + 100)) * co[2]) + 1
+tail <- exp(co[1] + c(n:(n + 100)) * co[2]) + 1
 f.tail <- prod(tail)
 f.tail      
 @ 
@@ -525,7 +525,7 @@ claims amount to forecast the next development period. The
 \emph{squaring} of the RAA triangle is calculated below, where an
 \emph{ultimate} column is appended to the right to accommodate the
 expected development beyond the oldest age (10) of the triangle due to
-the tail factor (1.005) being greater than unity. 
+the tail factor (1.009) being greater than unity. 
 <<>>=
 f <- c(f, f.tail)
 fullRAA <- cbind(RAA, Ult = rep(0, 10))
@@ -535,7 +535,7 @@ for(k in 1:n){
 round(fullRAA)
 @ 
 
-The total estimated outstanding loss under this method is about 53200:
+The total estimated outstanding loss under this method is about 54100:
 <<>>=
 sum(fullRAA[ ,11] - getLatestCumulative(RAA))
 @ 
@@ -555,7 +555,7 @@ displayed in favor of that multiplicative calculation.
 
 For example, suppose the actuary decides that the volume weighted
 factors from the RAA triangle are representative of expected future
-growth, but discards the 1.005 tail factor derived from the loglinear
+growth, but discards the 1.009 tail factor derived from the loglinear
 fit in favor of a five percent tail (1.05) based on loss data from a
 larger book of similar business. The LDF method might be displayed in
 R as follows. 


### PR DESCRIPTION
Three minor changes:

1) The calculation for the tail log-linear extrapolation given in the vignette had a minor error - the first development period in the extrapolation was too large by 1 (this is due to the differing definition of n in the vignette and in the tailfactor function in ChainLadder.R.  This has been corrected, and the result now agrees with the results of MackChainLadder(RAA, tail=TRUE).

2) The calculation of the tail using the log-linear extrapolation in the tailfactor function in ChainLadder.R had a potential error - when clratios has values of less than unity they are dropped, but the extrapolation was started from a quantity indexed by the length of f, not the value of fn.  This changes the results if clratios has a pattern like e.,g.: ... 1.1, 0.98,1.01,0.005 (i.e. a link ratio less than unity which is not the last value) - possible with noisy triangles.

3) Very minor fix to the comments in ChainLadder.R and MackChainLadder.R, since I noticed it, fixing notation for alpha which is now consistent with the documentation and Mack's original paper.