### PR TITLE
Convert column of Date class in as.triangle

### DIFF
--- a/R/Triangles.R
+++ b/R/Triangles.R
@@ -71,18 +71,19 @@ as.triangle.matrix <- function(Triangle, origin="origin", dev="dev", value="valu
 }
 
 as.triangle.data.frame <- function(Triangle, origin="origin", dev="dev", value="value", ...){
-  #  d <- dim(Triangle)
-  #  if(length(d) == 2 & d[1]==d[2]){
-  #      matrixTriangle <- as.matrix(Triangle)
-  #      matrixTriangle <- as.triangle(matrixTriangle)
-  #  }else{
+
+  isDate <- intersect(class(Triangle[[origin]]), "Date")
+  
+  if ( !is.null(isDate) ){
+    warning("Converting origin from Date to numeric")
+    Triangle[[origin]] <- as.numeric(Triangle[[origin]])
+  }
   
   fmla <- as.formula(paste(origin, "~", dev))
   matrixTriangle <- acast(Triangle, fmla, fun.aggregate = sum, 
                           value.var = value, fill = as.numeric(NA))
   names(dimnames(matrixTriangle)) <- c(origin, dev)
-  #      matrixTriangle <- .as.MatrixTriangle(Triangle, origin, dev, value)
-  #  }
+
   class(matrixTriangle) <- c("triangle", "matrix")
   return(matrixTriangle)
 }

--- a/R/Triangles.R
+++ b/R/Triangles.R
@@ -74,7 +74,7 @@ as.triangle.data.frame <- function(Triangle, origin="origin", dev="dev", value="
 
   isDate <- intersect(class(Triangle[[origin]]), "Date")
   
-  if ( !is.null(isDate) ){
+  if ( length(isDate) != 0 ){
     warning("Converting origin from Date to numeric")
     Triangle[[origin]] <- as.numeric(Triangle[[origin]])
   }


### PR DESCRIPTION
This change will resolve Issue#12 (https://github.com/mages/ChainLadder/issues/12). The problem stems from the fact that the rownames will always be character. Dates convert to character without any problem, but an attempt to convert those characters back to numeric can't be done.

This isn't exactly ideal, but will ensure that no downstream errors result. Users will get a warning when the date column is converted.