### PR TITLE
Triangles with Date Row.names test plot

### DIFF
--- a/inst/unitTests/runit.Triangles.r
+++ b/inst/unitTests/runit.Triangles.r
@@ -1,0 +1,13 @@
+test.Triangles.DateLabels <- function() {
+  # by Brian and Dan
+  op <- as.Date(paste0(2001:2010, "-01-01"))
+  lags <- 1:10
+  
+  triangle <- expand.grid(op, lags)
+  names(triangle) <- c("origin", "dev")
+  set.seed(1234)
+  triangle$value <- rnorm(100)
+  
+  triCL <- ChainLadder::as.triangle(triangle)
+  plot(triCL, lattice=TRUE)
+}


### PR DESCRIPTION
with lattice = TRUE
No longer fails with Brian's fix.
There is a new file in inst/unitTests, runit.Triangles.R, that can be used to test future changes to Triangles.R code. It currently contains only one testing function, test.Triangles.DateLabels.