### PR TITLE
Reglmresvchanges

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ Changes
 
   o Clarified error statements in MackChainLadder.
   
-  o Simplfied model extraction from lm
+  o Simplified model extraction from lm
   
 	- lm generates a warning when the fit is "essentially perfect".
     	  For development triangles that occurs when the link ratios are

--- a/NEWS
+++ b/NEWS
@@ -5,12 +5,13 @@ Changes
 
   o Clarified error statements in MackChainLadder.
   
-  o Simplified model extraction from lm
+  o Simplfied model extraction from lm
   
 	- lm generates a warning when the fit is "essentially perfect".
     	  For development triangles that occurs when the link ratios are
     	  indistinguishable within the machine’s tolerance.
-    	  Give an "information" message when that occurs and the development factor is unity.
+    	  Give an "information" message when that occurs and the
+	  development factor is unity.
 
 Bug Fixes
 

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,15 @@ Changes
     	  Give an "information" message when that occurs and the
 	  development factor is unity.
 
+  o Convert column of Date class in as.triangle; Change test from null to
+    length
+    - Triangles with Date Row.names test plot with lattice = TRUE no
+      longer fails with Brian's fix.
+      
+  o New /inst/unittests/runit.Triangles.R file for checking for continued
+    clean ChainLadder compilations whenever code in Triangles.R is
+    improved or otherwise changed.
+
 Bug Fixes
 
   o Fixed tail extrapolation in Vignette. Thanks to Mark Lee.
@@ -40,15 +49,6 @@ Bug Fixes
 	    3) Minor fix to the comments in ChainLadder.R and MackChainLadder.R,
 	       fixing notation for alpha which is now consistent with the
 	       documentation and Mack's original paper.
-
-  o Convert column of Date class in as.triangle; Change test from null to
-    length
-    - Triangles with Date Row.names test plot with lattice = TRUE no
-      longer fails with Brian's fix.
-      
-  o New /inst/unittests/runit.Triangles.R file for checking for continued
-    clean ChainLadder compilations whenever code in Triangles.R is
-    improved or otherwise changed.
 
   
 

--- a/NEWS
+++ b/NEWS
@@ -5,13 +5,12 @@ Changes
 
   o Clarified error statements in MackChainLadder.
   
-  o Simplfied model extraction from lm
+  o Simplified model extraction from lm
   
 	- lm generates a warning when the fit is "essentially perfect".
     	  For development triangles that occurs when the link ratios are
     	  indistinguishable within the machine’s tolerance.
-    	  Give an "information" message when that occurs and the
-	  development factor is unity.
+    	  Give an "information" message when that occurs and the development factor is unity.
 
 Bug Fixes
 

--- a/R/MackChainLadderFunctions.R
+++ b/R/MackChainLadderFunctions.R
@@ -164,10 +164,18 @@ Mack.S.E <- function(MackModel, FullTriangle, est.sigma="log-linear", weights, a
     }
     else {
       ## estimate sigma[n-1] via log-linear regression
-      sig.model <- estimate.sigma(sigma)
+      sig.model <- suppressWarnings(estimate.sigma(sigma))
       sigma <- sig.model$sigma
       
-      p.value.of.model <- summary(sig.model$model)$coefficient[2,4]
+      p.value.of.model <- tryCatch(summary(sig.model$model)$coefficient[2,4],
+                                   error = function(e) e)
+      if (inherits(p.value.of.model, "error")) {
+        warning(paste("'loglinear' model to estimate sigma_n doesn't appear appropriate.\n",
+                      "est.sigma will be overwritten to 'Mack'.\n",
+                      "Mack's estimation method will be used instead."))
+        est.sigma <- "Mack"
+      }
+      else
       if(p.value.of.model > 0.05){
         warning(paste("'loglinear' model to estimate sigma_n doesn't appear appropriate.",
                       "\np-value > 5.\n",
@@ -175,7 +183,8 @@ Mack.S.E <- function(MackModel, FullTriangle, est.sigma="log-linear", weights, a
                       "Mack's estimation method will be used instead."))
         
         est.sigma <- "Mack"
-      }else{
+      }
+      else{
         f.se[isna] <- sigma[isna]/sqrt(weights[1,isna]*FullTriangle[1,isna]^alpha[isna])
       }
     }

--- a/R/MackChainLadderFunctions.R
+++ b/R/MackChainLadderFunctions.R
@@ -142,7 +142,7 @@ Mack.S.E <- function(MackModel, FullTriangle, est.sigma="log-linear", weights, a
   sigma <- sapply(smmry, function(x) x$sigma)
   df <- sapply(smmry, function(x) x$df[2L])
   tolerance <- .Machine$double.eps
-  perfect.fit <- (df > 0) & (f.se < tolerance) & approx.equal(f, 1.000)
+  perfect.fit <- (df > 0) & (f.se < tolerance) # & approx.equal(f, 1.000)
   w <- which(perfect.fit)
   if (length(w)) {
     warn <- "Information: essentially no development in data for period(s):\n"

--- a/R/Triangles.R
+++ b/R/Triangles.R
@@ -72,7 +72,7 @@ as.triangle.matrix <- function(Triangle, origin="origin", dev="dev", value="valu
 
 as.triangle.data.frame <- function(Triangle, origin="origin", dev="dev", value="value", ...){
 
-  isDate <- intersect(class(Triangle[[origin]]), "Date")
+  isDate <- inherits(Triangle[[origin]], "Date")
   
   if ( length(isDate) != 0 ){
     warning("Converting origin from Date to numeric")

--- a/R/Triangles.R
+++ b/R/Triangles.R
@@ -72,12 +72,12 @@ as.triangle.matrix <- function(Triangle, origin="origin", dev="dev", value="valu
 
 as.triangle.data.frame <- function(Triangle, origin="origin", dev="dev", value="value", ...){
 
-  isDate <- inherits(Triangle[[origin]], "Date")
-  
-  if ( length(isDate) != 0 ){
-    warning("Converting origin from Date to numeric")
-    Triangle[[origin]] <- as.numeric(Triangle[[origin]])
-  }
+#  isDate <- inherits(Triangle[[origin]], "Date")
+#  
+#  if (isDate) {
+#    warning("Converting origin from Date to numeric")
+#    Triangle[[origin]] <- as.numeric(Triangle[[origin]])
+#  }
   
   fmla <- as.formula(paste(origin, "~", dev))
   matrixTriangle <- acast(Triangle, fmla, fun.aggregate = sum, 
@@ -148,10 +148,11 @@ print.triangle <- function(x, ...) {
 .as.LongTriangle <- function(Triangle, na.rm=FALSE){
   # 3/20/2013
   # Difference from old version: preserves names(dimnames) to be column names
-  # in the date.frame rather than forcing 'origin' and 'dev'
+  # in the data.frame rather than forcing 'origin' and 'dev'
   x <- Triangle
   nms <- names(dimnames(x))
-  .origin <- try(as.numeric(dimnames(x)[[nms[1L]]]))
+#  .origin <- try(as.numeric(dimnames(x)[[nms[1L]]]))
+  .origin <- dimnames(x)[[nms[1L]]]
   if(class(dimnames(x)[['dev']]) %in% "character"){
     if(.allisnumeric(dimnames(x)[['dev']])){
       .dev <- try(as.numeric(dimnames(x)[[nms[2L]]]))
@@ -164,11 +165,11 @@ print.triangle <- function(x, ...) {
   }else{
     .dev <- try(as.numeric(dimnames(x)[[nms[2L]]]))
   }
-  if(any(is.na(c(.origin, .dev)))){
-    stop(paste("The origin and dev. period columns have to be of type numeric or a character",
-               "which can be converted into numeric.\n"))
-  }
-  lx <- expand.grid(origin=.origin, dev=.dev)
+#  if(any(is.na(c(.origin, .dev)))){
+#    stop(paste("The origin and dev. period columns have to be of type numeric or a character",
+#               "which can be converted into numeric.\n"))
+#  }
+  lx <- expand.grid(origin=.origin, dev=.dev, stringsAsFactors = FALSE)
   ##    lx <- expand.grid(origin=dimnames(x)$origin, dev=dimnames(x)$dev)
   lx$value <- as.vector(x)
   if(na.rm){

--- a/R/glmReserve.R
+++ b/R/glmReserve.R
@@ -33,7 +33,22 @@ glmReserve <- function(triangle, var.power = 1, link.power = 0,
   if (is.null(attr(tr.incr, "exposure"))) {
     lda$offset <-  rep(0, nrow(lda))
   } else {
-    lda$offset <- fam$linkfun(attr(tr.incr, "exposure")[lda$origin - min (lda$origin) + 1])
+    # Allow exposures to be expanded to the long data.frame by matching
+    #   names(exposure) with triangle's origin values, or by the arithmetic
+    #   formula that has always been there, if triangles origin values are
+    #   convertible from their character representations to numeric.
+    expo <- attr(tr.incr, "exposure")
+    if (is.null(names(expo))) names(expo) <- NA
+    if (all(names(expo) %in% lda$origin)) lda$offset <- 
+        fam$linkfun(attr(tr.incr, "exposure")[lda$origin])
+    else {
+      numorig <- suppressWarnings(as.numeric(lda$origin))
+      if (any(is.na(numorig))) stop(
+        "Unnamed exposures incompatible when triangle's origin values are not convertible from character to numeric."
+      )
+      lda$offset <- 
+        fam$linkfun(attr(tr.incr, "exposure")[numorig - min (numorig) + 1])
+    }
   }
   
   # divide data 

--- a/inst/unitTests/runit.MackChainLadder.R
+++ b/inst/unitTests/runit.MackChainLadder.R
@@ -49,3 +49,16 @@ test.NoDevelopmentExample <- function(){
   m <- tryCatch(MackChainLadder(x, est.sigma = "Mack"), warning = function(w) w)
   checkTrue(!inherits(m, "warning"))
 }
+test.loglinear.NA.Example <- function(){
+  x <- matrix(byrow = TRUE, nrow = 4, ncol = 4,
+              dimnames = list(origin = LETTERS[1:4], dev = 1:4),
+              data = c(
+                100, 105, 105.00001, 105.00001,
+                200, 210, 210.00001, NA,
+                300, 315, NA, NA,
+                400, NA, NA, NA)
+  )
+  # This should no longer generate an error
+  m <- tryCatch(MackChainLadder(x, est.sigma = "log-linear"), error = function(e) e)
+  checkTrue(!inherits(m, "error"))
+}

--- a/inst/unitTests/runit.MackChainLadder.R
+++ b/inst/unitTests/runit.MackChainLadder.R
@@ -32,3 +32,20 @@ test.MackMortgageCVWithTail <- function() {
     MRT <- MackChainLadder(Mortgage, tail=1.05, tail.se = .05)
     checkEquals(round(tail(MRT$Total.ParameterRisk, 1) / summary(MRT)$Totals["IBNR", ], 2), .19)
 }
+test.NoDevelopmentExample <- function(){
+  # If there's essentially no development from one age to the next, lm will warn
+  # that it's "essentially perfect fit". Want to replace that with a better message.
+  # The solution is to suppress that message, detect a perfect.fit separately,
+  # and "cat" an informational message to the console.
+  x <- matrix(byrow = TRUE, nrow = 4, ncol = 4,
+              dimnames = list(origin = LETTERS[1:4], dev = 1:4),
+              data = c(
+                100, 105, 105.00001, 105.00001,
+                200, 210, 210.00001, NA,
+                300, 315, NA, NA,
+                400, NA, NA, NA)
+  )
+  # This should no longer generate a warning
+  m <- tryCatch(MackChainLadder(x, est.sigma = "Mack"), warning = function(w) w)
+  checkTrue(!inherits(m, "warning"))
+}

--- a/inst/unitTests/runit.glmReserving.r
+++ b/inst/unitTests/runit.glmReserving.r
@@ -1,0 +1,8 @@
+test.glmReserve.DateLabels <- function() {
+  expos <- (7 + 1:10 * 0.4) * 100
+  GenIns2 <- GenIns
+  rownames(GenIns2) <- paste0(2001:2010, "-01-01")
+  attr(GenIns2, "exposure") <- expos
+  (fit4 <- glmReserve(GenIns2))
+  }
+

--- a/inst/unitTests/runit.glmReserving.r
+++ b/inst/unitTests/runit.glmReserving.r
@@ -1,8 +1,11 @@
 test.glmReserve.DateLabels <- function() {
-  expos <- (7 + 1:10 * 0.4) * 100
+  expos <- (7 + 1:10 * 0.4) * 10
   GenIns2 <- GenIns
   rownames(GenIns2) <- paste0(2001:2010, "-01-01")
   attr(GenIns2, "exposure") <- expos
-  (fit4 <- glmReserve(GenIns2))
+  checkException(fit5 <- glmReserve(GenIns2))
+  names(expos) <- rownames(GenIns2)
+  attr(GenIns2, "exposure") <- expos
+  (fit6 <- glmReserve(GenIns2))
   }
 

--- a/man/glmReserve.Rd
+++ b/man/glmReserve.Rd
@@ -43,11 +43,33 @@ glmReserve(triangle, var.power = 1, link.power = 0, cum = TRUE,
 }
 }
 \details{
- This function takes an insurance loss triangle, converts it to incremental losses internally if necessary, transforms it to the long format (see \code{as.data.frame}) and fits the resulting loss data with a generalized linear model where the mean structure includes both the accident year and the development lag effects. The distributions allowed are the exponential family that admits a power variance function, that is, \eqn{V(\mu)=\mu^p}. This subclass of distributions is usually called the Tweedie distribution and includes many commonly used distributions as special cases. This function does not allow the user to specify the GLM options through the usual \code{\link[stats]{family}} argument, but instead, it uses the \code{\link[statmod]{tweedie}} family internally and takes two arguments \code{var.power} and \code{link.power} through which the user still has full control of the distribution forms and link functions. The argument \code{var.power} determines which specific distribution is to be used, and \code{link.power} determines the form of the link function. When the Tweedie compound Poisson distribution \code{1 < p < 2} is to be used, the user has the option to specify \code{var.power = NULL}, where the variance power \code{p} will be estimated from the data using the \code{cplm} package. The \code{bcplm} function in the \code{cplm} package also has an example for the Bayesian compound Poisson loss reserving model. See details in \code{\link[statmod]{tweedie}}, \code{\link[cplm]{cpglm}} and  \code{\link[cplm]{bcplm}}. 
- 
-Also, the function allows certain measures of exposures to be used in an offset term in the underlying GLM. To do this, the user should not use the usual \code{offset} argument in \code{glm}. Instead, one specifies the exposure measure for each accident year through the \code{exposure} attribute of \code{triangle}. Make sure that these exposures are in the original scale (no log transformations for example), and they are in the order consistent with the accident years. If the \code{exposure} attribute is not \code{NULL}, the \code{glmReserve} function will use these exposures, link-function-transformed, in the offset term of the GLM. For example, if the link function is \code{log}, then the log of the exposure is used as the offset, not the original exposure. See the examples below. Moreover, the user MUST NOT supply the typical \code{offset} or \code{weight} as arguments in the list of additional arguments \code{\dots}. \code{offset} should be specified as above, while \code{weight} is not implemented (due to prediction reasons). 
+This function takes an insurance loss triangle, converts it to incremental losses internally if necessary, transforms it to the long format (see \code{as.data.frame}) and fits the resulting loss data with a generalized linear model where the mean structure includes both the accident year and the development lag effects.
+The distributions allowed are the exponential family that admits a power variance function, that is, \eqn{V(\mu)=\mu^p}.
+This subclass of distributions is usually called the Tweedie distribution and includes many commonly used distributions as special cases.
 
-Two methods are available to assess the prediction error of the estimated loss reserves. One is using the analytical formula (\code{mse.method = "formula"}) derived from the first-order Taylor approximation. The other is using bootstrapping (\code{mse.method = "bootstrap"}) that reconstructs the triangle \code{nsim} times by sampling with replacement from the GLM (Pearson) residuals. Each time a new triangle is formed, GLM is fitted and corresponding loss reserves are generated. Based on these predicted mean loss reserves, and the model assumption about the distribution forms, realizations of the predicted values are generated via the \code{rtweedie} function. Prediction errors as well as other uncertainty measures such as quantiles and predictive intervals can be calculated based on these samples. 
+This function does not allow the user to specify the GLM options through the usual \code{\link[stats]{family}} argument, but instead, it uses the \code{\link[statmod]{tweedie}} family internally and takes two arguments, \code{var.power} and \code{link.power}, through which the user still has full control of the distribution forms and link functions.
+The argument \code{var.power} determines which specific distribution is to be used, and \code{link.power} determines the form of the link function.
+
+When the Tweedie compound Poisson distribution \code{1 < p < 2} is to be used, the user has the option to specify \code{var.power = NULL}, where the variance power \code{p} will be estimated from the data using the \code{cplm} package. The \code{bcplm} function in the \code{cplm} package also has an example for the Bayesian compound Poisson loss reserving model.
+See details in \code{\link[statmod]{tweedie}}, \code{\link[cplm]{cpglm}} and  \code{\link[cplm]{bcplm}}. 
+ 
+\code{glmReserve} allows certain measures of exposures to be used in an offset term in the underlying GLM.
+To do this, the user should not use the usual \code{offset} argument in \code{glm}.
+Instead, one specifies the exposure measure for each accident year through the \code{exposure} attribute of \code{triangle}. 
+Make sure that these exposures are in the original scale (no log transformations for example).
+If the vector is named, make sure the names coincide with the rownames/origin of the triangle.
+If the vector is unnamed, make sure the exposures are in the order consistent with the accident years, \bold{and the character rownames of the Triangle must be convertible to numeric.} 
+If the \code{exposure} attribute is not \code{NULL}, the \code{glmReserve} function will use these exposures, link-function-transformed, in the offset term of the GLM. 
+For example, if the link function is \code{log}, then the log of the exposure is used as the offset, not the original exposure. 
+See the examples below. 
+Moreover, the user MUST NOT supply the typical \code{offset} or \code{weight} as arguments in the list of additional arguments \code{\dots}. \code{offset} should be specified as above, while \code{weight} is not implemented (due to prediction reasons). 
+
+Two methods are available to assess the prediction error of the estimated loss reserves.
+One is using the analytical formula (\code{mse.method = "formula"}) derived from the first-order Taylor approximation.
+The other is using bootstrapping (\code{mse.method = "bootstrap"}) that reconstructs the triangle \code{nsim} times by sampling with replacement from the GLM (Pearson) residuals.
+Each time a new triangle is formed, GLM is fitted and corresponding loss reserves are generated.
+Based on these predicted mean loss reserves, and the model assumption about the distribution forms, realizations of the predicted values are generated via the \code{rtweedie} function.
+Prediction errors as well as other uncertainty measures such as quantiles and predictive intervals can be calculated based on these samples. 
 
 }
 
@@ -58,13 +80,15 @@ The use of GLM in insurance loss reserving has many compelling aspects, e.g.,
   \item it provides a more coherent modeling framework than the Mack method;
   \item all the relevant established statistical theory can be directly applied to perform hypothesis testing and diagnostic checking;
 }
-However,  the user should be cautious of some of the key assumptions that underline the GLM model, in order to determine whether this model is appropriate for the problem considered:
+However,  the user should be cautious of some of the key assumptions that underlie the GLM model, in order to determine whether this model is appropriate for the problem considered:
 \itemize{
   \item the GLM model assumes no tail development, and it only projects losses to the latest time point of the observed data. To use a model that enables tail extrapolation, please consider the growth curve model \code{\link{ClarkLDF}} or \code{\link{ClarkCapeCod}};
-  \item the model assumes that each incremental loss is independent of all the others. This assumption may not be valid in that cells from the same calendar year are usually correlated due to inflation or business operating factors;
+  \item the model assumes that each incremental loss is independent of all the others.
+  This assumption may not be valid in that cells from the same calendar year are usually correlated due to inflation or business operating factors;
   \item the model tends to be over-parameterized, which may lead to inferior predictive performance. 
 }
-To solve these potential problems, many variants of the current basic GLM model have been proposed in the actuarial literature. Some of these may be included in the future release.
+To solve these potential problems, many variants of the current basic GLM model have been proposed in the actuarial literature.
+Some of these may be included in the future release.
 
 }
 
@@ -124,6 +148,13 @@ expos <- (7 + 1:10 * 0.4) * 100
 GenIns2 <- GenIns
 attr(GenIns2, "exposure") <- expos
 (fit4 <- glmReserve(GenIns2))
+# If the triangle's rownames are not convertible to numeric,
+# supply names to the exposures
+GenIns3 <- GenIns2
+rownames(GenIns3) <- paste0(2007:2016, "-01-01")
+names(expos) <- rownames(GenIns3)
+attr(GenIns3, "exposure") <- expos
+(fit4b <- glmReserve(GenIns3))
 
 # use bootstrapping to compute prediction error
 \dontrun{


### PR DESCRIPTION
Relaxed requirement for rownames(Triangle) to be convertible to numeric. That requirement was in glmReserve and no where else. "exposure" attribute may now have names which will allow glmReserve to assign to the correct origins. glmReserve "help" includes a new example showing how to use names with exposures.

plot(Triangle, lattice = TRUE) now works even when rownames(Triangle) are not convertible to numeric.

Requirement in .as.LongTriangle for rownames(Triangle) to be convertible to numeric was removed. 

New unit tests added to check the new functionality. 
All package Checks passed in RStudio.