### PR TITLE
Mack se recursion rewrite

### DIFF
--- a/R/MackChainLadderFunctions.R
+++ b/R/MackChainLadderFunctions.R
@@ -142,7 +142,7 @@ Mack.S.E <- function(MackModel, FullTriangle, est.sigma="log-linear", weights, a
   sigma <- sapply(smmry, function(x) x$sigma)
   df <- sapply(smmry, function(x) x$df[2L])
   tolerance <- .Machine$double.eps
-  perfect.fit <- (df > 0) & (f.se < tolerance) # & approx.equal(f, 1.000)
+  perfect.fit <- (df > 0) & (f.se < tolerance)
   w <- which(perfect.fit)
   if (length(w)) {
     warn <- "Information: essentially no variation in development data for period(s):\n"

--- a/vignettes/NEWS.Rmd
+++ b/vignettes/NEWS.Rmd
@@ -179,7 +179,7 @@ and, of course, add other runit scripts as warrantted.
 By default, R's `lm` method generates a warning when it detects
 an "essentially perfect fit".
 This can happen when one column of a triangle is identical to the previous column;
-i.e., when all link ratios are the same.
+i.e., when all link ratios in a column are the same.
 In the example below, the second column is a fixed constant, 1.05,
 times the first column.
 ChainLadder previously issued the lm warning below.
@@ -202,7 +202,7 @@ Warning messages:
 ```
 which may have raised a concern with the user when none was warranted.
 
-Now ChainLadder issues an informational message at the console:
+Now ChainLadder issues an "informational warning":
 
 ```{r echo = FALSE}
 x <- matrix(byrow = TRUE, nrow = 4, ncol = 4, 

--- a/vignettes/NEWS.Rmd
+++ b/vignettes/NEWS.Rmd
@@ -188,8 +188,8 @@ ChainLadder previously issued the lm warning below.
 x <- matrix(byrow = TRUE, nrow = 4, ncol = 4, 
             dimnames = list(origin = LETTERS[1:4], dev = 1:4),
             data = c(
-              100, 105, 105.00001, 105.00001,
-              200, 210, 210.00001, NA,
+              100, 105, 106, 106.5,
+              200, 210, 211, NA,
               300, 315, NA, NA,
               400, NA, NA, NA)
             )
@@ -208,8 +208,8 @@ Now ChainLadder issues an "informational warning":
 x <- matrix(byrow = TRUE, nrow = 4, ncol = 4, 
             dimnames = list(origin = LETTERS[1:4], dev = 1:4),
             data = c(
-              100, 105, 105.00001, 105.00001,
-              200, 210, 210.00001, NA,
+              100, 105, 106, 106.5,
+              200, 210, 211, NA,
               300, 315, NA, NA,
               400, NA, NA, NA)
             )


### PR DESCRIPTION
To address my new issue 15, I rewrote the MackRecursive.S.E to be row-wise r.t. column-wise. Now when a development age (column) has more than one row in the triangle whose latest value is at that age, the Mack statistics calculate correctly -- the values for the last two rows below are identical and the Mack.S.E value for the second row is no longer zero:

> G <- rbind(GenIns, `11`=GenIns[10,])
> MackChainLadder(G)
MackChainLadder(Triangle = G)

      Latest Dev.To.Date  Ultimate      IBNR  Mack.S.E CV(IBNR)
1  3,901,463      1.0000 3,901,463         0         0      NaN
2  5,339,085      0.9826 5,433,719    94,634    71,835    0.759
3  4,909,315      0.9127 5,378,826   469,511   119,474    0.254
4  4,588,268      0.8661 5,297,906   709,638   131,573    0.185
5  3,873,311      0.7973 4,858,200   984,889   260,530    0.265
6  3,691,712      0.7223 5,111,171 1,419,459   410,407    0.289
7  3,483,130      0.6153 5,660,771 2,177,641   557,796    0.256
8  2,864,498      0.4222 6,784,799 3,920,301   874,882    0.223
9  1,363,294      0.2416 5,642,266 4,278,972   970,960    0.227
10   344,014      0.0692 4,969,825 4,625,811 1,362,981    0.295
11   344,014      0.0692 4,969,825 4,625,811 1,362,981    0.295

