### PR TITLE
 Update print methods to behave in line with the generic's description

### DIFF
--- a/R/BootstrapReserve.R
+++ b/R/BootstrapReserve.R
@@ -295,6 +295,7 @@ print.BootChainLadder <- function(x,probs=c(0.75,0.95),...){
   rownames(Totals)[4] <- "IBNR.S.E"
   print(format(Totals, big.mark=",",digits=3), quote=FALSE)
   
+  invisible(x)
 }
 
 

--- a/R/MackChainLadderFunctions.R
+++ b/R/MackChainLadderFunctions.R
@@ -428,8 +428,8 @@ print.MackChainLadder <- function(x,...){
   Totals[1:6,] <- formatC(Totals[1:6,], big.mark=",",digits=2,format="f")
   cat("\n")
   print(Totals, quote=FALSE)
-  #invisible(x)
   
+  invisible(x)
 }
 
 
@@ -714,6 +714,8 @@ print.Mack <- function(x,...){
   df$Mack.S.E=x$Mack.S.E[,n]
   df$CV=df$Mack.S.E/df$IBNR
   print(df)
+  
+  invisible(x)
 }
 
 

--- a/R/MunichChainLadderFunctions.R
+++ b/R/MunichChainLadderFunctions.R
@@ -224,6 +224,7 @@ print.MunichChainLadder <- function(x,...){
     cat("\nTotals\n")
     print(format(summary.x$Totals, big.mark = ",", digits = 2),...)
 
+    invisible(x)
 }
 
 ##############################################################################

--- a/R/Triangles.R
+++ b/R/Triangles.R
@@ -162,8 +162,11 @@ plot.triangle <- function(x,type="b",
 }
 
 print.triangle <- function(x, ...) {
+  ret <- x
   class(x) <- tail(class(x), -1)
   NextMethod(x, ...)
+  
+  invisible(ret)
 }
 
 .as.MatrixTriangle <- function(x, origin="origin", dev="dev", value="value"){

--- a/R/ata.r
+++ b/R/ata.r
@@ -75,5 +75,9 @@ summary.ata <- function(object, digits=3, ...) {
         ) 
     }
 
-print.ata <- function(x, ...) print(summary(x), ...)
+print.ata <- function(x, ...) {
+  print(summary(x), ...)
+  
+  invisible(x)
+}
 

--- a/R/clark.r
+++ b/R/clark.r
@@ -784,6 +784,8 @@ print.ClarkLDF <- function(x, Amountdigits=0, LDFdigits=3, CVdigits=3, row.names
         names = c(names(y)[1:6], "CV%")
         )
     print(z, row.names = row.names, ...)
+    
+    invisible(x)
     }
 
 summary.ClarkCapeCod <- function(object, ...) {
@@ -818,6 +820,8 @@ print.ClarkCapeCod <- function(x, Amountdigits=0, ELRdigits=3, Gdigits=4, CVdigi
         names = c(names(y)[1:8], "CV%")
         )
     print(z, row.names = FALSE, ...)
+    
+    invisible(x)
     }
 
 plot.clark <- function(x, ...) {

--- a/R/glmReserve.R
+++ b/R/glmReserve.R
@@ -231,8 +231,11 @@ summary.glmReserve <- function(object, type = c("triangle", "model"), ...){
     summary(object$model)
 }
 
-print.glmReserve <- function(x, ...)
+print.glmReserve <- function(x, ...) {
   summary(x)
+  
+  invisible(x)
+}
 
 # return pearson residuals (scaled)
 residuals.glmReserve <- function(object, ...){

--- a/R/tweedieReserve.R
+++ b/R/tweedieReserve.R
@@ -569,6 +569,8 @@ print.tweedieReserve <- function(x,...){
     out <- x$summary[c("Latest", "Det.IBNR", "Ultimate")]
   }
   print(out)  
+  
+  invisible(x)
 }
 
 summary.tweedieReserve <- function(object,

--- a/inst/unitTests/runit.BootChainLadder.R
+++ b/inst/unitTests/runit.BootChainLadder.R
@@ -1,0 +1,5 @@
+test.print.BootChainLadder <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- BootChainLadder(RAA)
+  checkEquals(res, print(res))
+}

--- a/inst/unitTests/runit.MackChainLadder.R
+++ b/inst/unitTests/runit.MackChainLadder.R
@@ -179,3 +179,9 @@ test.MackNANissue <- function(){
   checkEquals(summary(MackChainLadder(MackNANTriIssue, est.sigma="Mack"))$Totals[1,1],
               1900)
 }
+
+test.print.MackChainLadder <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- MackChainLadder(RAA)
+  checkEquals(res, print(res))
+}

--- a/inst/unitTests/runit.MunichChainLadder.R
+++ b/inst/unitTests/runit.MunichChainLadder.R
@@ -1,0 +1,5 @@
+test.print.MunichChainLadder <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- MunichChainLadder(MCLpaid, MCLincurred, est.sigmaP = 0.1, est.sigmaI = 0.1)
+  checkEquals(res, print(res))
+}

--- a/inst/unitTests/runit.ata.R
+++ b/inst/unitTests/runit.ata.R
@@ -1,0 +1,5 @@
+test.print.ata <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- ata(GenIns)
+  checkEquals(res, print(res))
+}

--- a/inst/unitTests/runit.clark.r
+++ b/inst/unitTests/runit.clark.r
@@ -248,19 +248,17 @@ test.correct_SummaryCapeCod_comparison <- function() {
     checkTrue(all((zInf[["FutureGrowthFactor"]] > z240[["FutureGrowthFactor"]])[1:10]))
     }
 
-test.class_returned_by_print.ClarkLDF <- function() {
-    x <- ClarkLDF(RAA)
-    z <- print(x)
-    y <- sapply(z, class)
-    checkTrue(all(y == "character"))
-    }
+test.print.ClarkLDF <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- ClarkLDF(RAA)
+  checkEquals(res, print(res))
+}
 
-test.class_returned_by_print.ClarkCapeCod <- function() {
-    x <- ClarkCapeCod(RAA, Premium=25000)
-    z <- print(x)
-    y <- sapply(z, class)
-    checkTrue(all(y == "character"))
-    }
+test.print.ClarkCapeCod <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- ClarkCapeCod(RAA, Premium = 25000)
+  checkEquals(res, print(res))
+}
 
 test.zero_expected_value <- function() {
     # Create a new environment, store ages we know will 

--- a/inst/unitTests/runit.glmReserving.r
+++ b/inst/unitTests/runit.glmReserving.r
@@ -9,3 +9,8 @@ test.glmReserve.DateLabels <- function() {
   (fit6 <- glmReserve(GenIns2))
   }
 
+test.print.glmReserve <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- glmReserve(GenIns / 1000)
+  checkEquals(res, print(res))
+}

--- a/inst/unitTests/runit.triangle.R
+++ b/inst/unitTests/runit.triangle.R
@@ -1,0 +1,10 @@
+test.print.triangle <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- triangle(c(100, 150, 175, 180, 200),
+                  c(110, 168, 192, 205),
+                  c(115, 169, 202),
+                  c(125, 185),
+                  c(150)
+  )
+  checkEquals(res, print(res))
+}

--- a/inst/unitTests/runit.tweedieReserve.R
+++ b/inst/unitTests/runit.tweedieReserve.R
@@ -25,3 +25,12 @@ test.tweedieReserve <- function() {
   checkEquals(rep_2$Diagnostic,diag_2,tol=0.01, checkNames = FALSE)
   
 }
+
+test.print.tweedieReserve <- function() {
+  # Test that print(x) returns x; see ?print
+  res <- tweedieReserve(MW2008, var.power = 1,link.power = 0, 
+                        design.type = c(1, 1, 0), rereserving = TRUE,
+                        progressBar = TRUE
+  )
+  checkEquals(res, print(res))
+}


### PR DESCRIPTION
`?print` states that "`print` prints its argument and returns it invisibly". The existing code does not behave that way (see mages/ChainLadder#56).

I am including 2 commits:

* Add unit tests that cover the expected behaviour
* Adjust print methods to pass unit tests

Thanks for considering.