### PR TITLE
Update MunichChainLadderFunctions.R

### DIFF
--- a/R/MunichChainLadderFunctions.R
+++ b/R/MunichChainLadderFunctions.R
@@ -74,11 +74,13 @@ MunichChainLadder <- function(Paid, Incurred,
 
     ## Estimate the residuals
 
+    weights_t <- weights 
+    diag(weights_t[1:m,n:1]) <- NA
+    weights_t <- weights_t[1:(m-1),1:(n-1)]
+	
     Paidf <-  t(matrix(rep(MackPaid$f[-n],(m-1)), ncol=(m-1)))
     PaidSigma <- t(matrix(rep(MackPaid$sigma,(m-1)), ncol=(m-1)))
     PaidRatios <- Paid[-m,-1]/Paid[-m,-n]
-    t <- (row(PaidRatios)+col(PaidRatios)-3)
-    weights_t <- ifelse(t<=max(col(PaidRatios)-sum(weights[,1])-1), 0, ifelse(t>max(col(PaidRatios)-2), NA, 1))
     PaidResiduals <- (PaidRatios - Paidf)/PaidSigma[, 1:ncol(Paidf)] * sqrt(Paid[-m,-n])*weights_t
 
     Incurredf <-  t(matrix(rep(MackIncurred$f[-n],(m-1)), ncol=(m-1)))


### PR DESCRIPTION
Hi Markus,
I checked the cause of the error on the old example. The script that created the residual weight matrix (weight_t) was not compatible with the data in the example. The proposed change solves the problem.